### PR TITLE
0.5.0 RC hotfix

### DIFF
--- a/scenarios/03_Banished_Saurians.cfg
+++ b/scenarios/03_Banished_Saurians.cfg
@@ -69,13 +69,6 @@
 			canrecruit = yes
 			[ai]
 				passive_leader=yes
-	      [goal]
-                name=target
-                [criteria]
-                    id=Ashuran
-                [/criteria]
-                value=10.0
-            [/goal]
             [goal]
                 name=target
                 [criteria]


### PR DESCRIPTION
Pe_em na pewno to testowałeś? :P Bo nieumarli wybierają teraz najkrótsza ścieżkę do lidera jaszczurów, czyli... przez jednostki gracza. Zastąpiłem to targetem na teren, i w trakcie testów jednostki idą teraz po połowie na most i na gracza. Więc póki jest dobrze to nic bym nie zmieniał. :D
