### PR TITLE
0.5.2 Piko 4b

### DIFF
--- a/scenarios/04B_Krull_the_Rock.cfg
+++ b/scenarios/04B_Krull_the_Rock.cfg
@@ -71,8 +71,8 @@
 		side = 2
 		controller = ai
 		recruit = Troll Whelp
-		{GOLD 100 75 50}
-		{INCOME 8 7 6}
+		{GOLD 50 50 50}
+		{INCOME 5 5 5}
 		[ai]
 			leader_aggression=-20.0
 			caution=10.0

--- a/scenarios/05_Gelu-Aben_besieged.cfg
+++ b/scenarios/05_Gelu-Aben_besieged.cfg
@@ -146,7 +146,7 @@
 			type = Orcish Warrior
 			canrecruit = yes
 		[ai]
-			turns=1-7
+			turns=1-10
 			grouping=defensive
 			aggression=-8.0
 			caution=6.0
@@ -167,7 +167,7 @@
 			[/avoid]
 		[/ai]
 		[ai]
-			turns=8-30
+			turns=11-30
 			time_of_day=dawn,morning,afternoon
 			leader_aggression=-6.0
 			grouping=defensive
@@ -183,7 +183,7 @@
 			[/goal]
 		[/ai]
 		[ai]
-			turns=8-30
+			turns=11-30
 			leader_aggression=-6.0
 			time_of_day=dusk,first_watch,second_watch
 			aggression=-3.0

--- a/utils/04B__units.cfg
+++ b/utils/04B__units.cfg
@@ -42,6 +42,7 @@
 		x=35
 		y=14
 	[/unit]
+	#endif
 	[unit]
 		canrecruit=no
 		extra_recruit=""
@@ -52,7 +53,6 @@
 		x=34
 		y=11
 	[/unit]
-	#endif
 	[unit]
 		canrecruit=no
 		extra_recruit=""


### PR DESCRIPTION
Dopracowanie balansu scenariusza. Krull ma teraz wystarczająco wojska by
radzić sobie z obroną, ale nie jest na tyle silny by samodzielnie zabić
lidera orków.

Dodatkowo, przedłużyłem okres, w którym Gewold ma passive_leadera, z 8
tur do 10. Do tej pory jednostki wroga powinny być już wystarczająco
osłabione, by mógł on podać pomocną dłoń i zdobyć trochę expa, bez
narażania swojego życia.
